### PR TITLE
Fixes issue 164 by not accessing stream position to determine central…

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
@@ -290,7 +290,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="centralDirOffset">The offset of the dentral directory.</param>
 		public void WriteZip64EndOfCentralDirectory(long noOfEntries, long sizeEntries, long centralDirOffset)
 		{
-			long centralSignatureOffset = stream_.Position;
+			long centralSignatureOffset = centralDirOffset + sizeEntries;
 			WriteLEInt(ZipConstants.Zip64CentralFileHeaderSignature);
 			WriteLELong(44);    // Size of this record (total size of remaining fields in header or full size - 12)
 			WriteLEShort(ZipConstants.VersionMadeBy);   // Version made by


### PR DESCRIPTION
… signature offset (instead, use central directory offset + size of all entries)

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
